### PR TITLE
use https: protocol to avoid "Mixed Content"

### DIFF
--- a/mspace.js
+++ b/mspace.js
@@ -18,7 +18,7 @@
             if (Math.abs(box.height - 23) > 1  || Math.abs(box.width - 77) > 1) {
                 // Insert the mathml.css stylesheet.
                 link = document.createElement("link");
-                link.href = "http://fred-wang.github.io/mathml.css/mathml.css";
+                link.href = (location.protocol === "https:" ? "https:" : "http:") + "//fred-wang.github.io/mathml.css/mathml.css";
                 link.rel = "stylesheet";
                 document.head.appendChild(link);
             }


### PR DESCRIPTION
Mixed Content: The page at 'https://yaffle.github.io/mathml-to-clipboard/example.html' was loaded over HTTPS, but requested an insecure stylesheet 'http://fred-wang.github.io/mathml.css/mathml.css'. This request has been blocked; the content must be served over HTTPS