### PR TITLE
Don't margin unary operators.

### DIFF
--- a/mathml.css
+++ b/mathml.css
@@ -178,7 +178,7 @@ mspace {
 mi {
     font-style: italic;
 }
-mo {
+mo:not(:first-child):not(:last-child) {
     margin-right: .2em;
     margin-left: .2em;
 }


### PR DESCRIPTION
An operator by itself, like `<math><mo>+</mo></math>`, or one that is used as a unary operator like in `<math><mo>-</mo><mn>5</mn></math>` don't have margins in MathML-browsers.

This can be fixed by only selecting `<mo>`s that aren't the first child. I also ignored `<mo>`s that are the last child, as otherwise parenthesis would be asymmetric in some cases.

Now for some examples. Assume that all numbers/letters are in `<mn>` resp. `<mi>`, and all operators and parenthesis are in `<mo>`. `␣` is a margin of the operator next to it.

How Firefox renders MathML:
`+`
`-5`
`5␣×␣`
`3␣+␣5`
`(a␣×␣b)`   -- parenthesis are a special case it seems.

This CSS before the change:
`␣+␣`
`␣-␣5`
`5␣×␣`
`3␣+␣5`
`␣(␣a␣×␣b␣)␣`

After my proposed change:
`+`
`-5`
`5×`          -- Not correct!
`3␣+␣5`
`(a␣×␣b)`