### PR TITLE
fix: remove duplicate selector

### DIFF
--- a/mathml.css
+++ b/mathml.css
@@ -237,7 +237,6 @@ annotation, annotation-xml {
     font-family: monospace;
     display: none !important;
 }
-math:active > semantics > *:first-child,
 math:active > semantics > *:first-child {
     display: none !important;
 }


### PR DESCRIPTION
Was running stylelint on this file upstream in mdn/yari and this was on of the function things it flagged. Not sure if one was supposed to be an older format `::` version or something, but currently it's just the same selector twice