### PR TITLE
fix: don't duplicate mfrac selector

### DIFF
--- a/mathml.css
+++ b/mathml.css
@@ -21,7 +21,7 @@ mfrac {
     display: inline-block !important;
     vertical-align: -50%;
     border-collapse: collapse;
-    text-align: center;
+    text-align: center !important;
 }
 mfrac > * {
     display: block !important;
@@ -243,9 +243,4 @@ math:active > semantics > *:first-child {
 }
 math:active annotation:first-of-type {
     display: inline !important;
-}
-
-/* fix */
-mfrac{ 
-   text-align: center; /* was done previously (above) */
 }


### PR DESCRIPTION
`!important` isn't usually a great solution, but seems a better idea than duplicating the selector and relying on the order in the file